### PR TITLE
Give fleet tests more time

### DIFF
--- a/fleet_test.go
+++ b/fleet_test.go
@@ -13,7 +13,7 @@ import (
 const (
 	fleetctlBinPath = "/usr/bin/fleetctl"
 	tryTimes = 5
-	tryInterval = 500 * time.Millisecond
+	tryInterval = time.Second
 	serviceData = `[Unit]
 Description=Hello World
 [Service]


### PR DESCRIPTION
fleet actions are taking too long in larger clusters. We can bump up the timing of coretest for now, since fleet is still doing the right thing, just clearly not as quickly as we would like.
