### PR TITLE
Fix for coreos/coretest#35 (coretest should be using ntp...)

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -65,7 +65,7 @@ func TestDockerEcho(t *testing.T) {
 	}
 }
 
-func TestNtpDate(t *testing.T) {
+func TestNTPDate(t *testing.T) {
 	t.Parallel()
 	errc := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
Previously coretest was using tlsdate to check and make sure that
it could perform outbound network connectivity to a tlsdate
compatible endpoint.  This change switches to ntpdate using similar
semantics.
