### PR TITLE
systemd: check multi-user.target instead of default.target

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -151,7 +151,7 @@ func TestInstalledUpdateEngineRsaKeys(t *testing.T) {
 func TestServicesActive(t *testing.T) {
 	t.Parallel()
 	units := []string{
-		"default.target",
+		"multi-user.target",
 		"docker.socket",
 		"ntpd.service",
 		"update-engine.service",


### PR DESCRIPTION
The behavior of `default.target` is a bit special and doesn't report as
active consistently even though it is an alias for `multi-user.target`
which is indeed active. Not really worth any more of our time figuring
out why this is the case so just switch the check.

Required for systemd 217.
